### PR TITLE
Drag and drop

### DIFF
--- a/public/assets/js/board.js
+++ b/public/assets/js/board.js
@@ -47,7 +47,7 @@ function handleLogout() {
 
 function createLists(lists) {
   let $listContainers = lists.map(function(list) {
-    let $listContainer = $('<div class="list">').data('id', list.id);
+    let $listContainer = $('<div class="list">').data(list);
     let $header = $('<header>');
     let $headerButton = $('<button>')
       .text(list.title)
@@ -107,7 +107,35 @@ function renderBoard() {
 }
 
 function makeSortable() {
-  Sortable.create($boardContainer[0]);
+  Sortable.create($boardContainer[0], {
+    animation: 400,
+    easing: 'cubic-bezier(0.785, 0.135, 0.15, 0.86)',
+    swapThreshold: 0.85,
+    filter: '.add',
+    ghostClass: 'ghost',
+    onMove: function(event) {
+      let shouldMove = !$(event.related).hasClass('add');
+      return shouldMove;
+    },
+    onEnd: function(event) {
+      let { id, position } = $(event.item).data();
+      let newPosition = event.newIndex + 1;
+
+      if (position === newPosition) {
+        return;
+      }
+
+      $.ajax({
+        url: `/api/lists/${id}`,
+        method: 'PUT',
+        data: {
+          position: newPosition
+        }
+      }).then(function() {
+        init();
+      });
+    }
+  });
 }
 
 function openListCreateModal() {

--- a/public/assets/js/board.js
+++ b/public/assets/js/board.js
@@ -102,6 +102,12 @@ function renderBoard() {
 
   $boardContainer.empty();
   $boardContainer.append($lists);
+
+  makeSortable();
+}
+
+function makeSortable() {
+  Sortable.create($boardContainer[0]);
 }
 
 function openListCreateModal() {

--- a/public/assets/js/board.js
+++ b/public/assets/js/board.js
@@ -136,6 +136,36 @@ function makeSortable() {
       });
     }
   });
+
+  $('.list > ul').each(function(index, element) {
+    Sortable.create(element, {
+      group: 'cards',
+      ghostClass: 'ghost',
+      animation: 200,
+      easing: 'cubic-bezier(0.785, 0.135, 0.15, 0.86)',
+      onEnd: function(event) {
+        let oldList = $(event.from).parent().data().id;
+        let newList = $(event.to).parent().data().id;
+        let { id, position } = $(event.item.childNodes[0]).data();
+        let newPosition = event.newIndex + 1;
+
+        if (newPosition === position && newList === oldList) {
+          return;
+        }
+
+        $.ajax({
+          url: `/api/cards/${id}`,
+          method: 'PUT',
+          data: {
+            position: newPosition,
+            list_id: newList
+          }
+        }).then(function() {
+          init();
+        });
+      }
+    });
+  });
 }
 
 function openListCreateModal() {

--- a/public/board.html
+++ b/public/board.html
@@ -129,6 +129,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="/assets/js/ajax-setup.js"></script>
+    <script src="https://unpkg.com/sortablejs@1.8.4/Sortable.min.js"></script>
     <script src="https://unpkg.com/micromodal/dist/micromodal.min.js"></script>
     <script src="/assets/js/board.js"></script>
   </body>


### PR DESCRIPTION
Addresses Issues #12 and #13 

* Cards and lists can now be dragged-and-dropped to reorder lists, reorder cards, or move cards across lists; the 'Add another list' button does not participate in reordering; AJAX calls are made when a list or card is dropped to update the `position` attribute in the database and preserve the change without a page refresh:

![2019-10-07 15 41 53](https://user-images.githubusercontent.com/25443574/66354333-5883d600-e919-11e9-897f-21933257909c.gif)

![2019-10-07 15 42 19](https://user-images.githubusercontent.com/25443574/66354345-5de12080-e919-11e9-8e2f-e3c3eef2b9da.gif)
